### PR TITLE
Add docker compose test to CI runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - checkout
       - run: docker-compose build
-      - run: docker-compse up
+      - run: docker-compose up
       - run:
           name: install dockerize
           command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,8 @@ jobs:
           name: install dockerize
           command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
           environment:
-            DOCKERIZE_VERSION: v0.3.0
-      - run: dockerize -wait http://0.0.0.0:8000/ -timeout 20m
+            DOCKERIZE_VERSION: v0.6.1
+      - run: dockerize -wait http://0.0.0.0:8000/swagger/ -timeout 20m
   build:
     working_directory: ~/CouncilTag-Django
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
           environment:
             DOCKERIZE_VERSION: v0.6.1
-      - run: dockerize -wait http://0.0.0.0:8000/swagger/ -timeout 20m
+      - run: dockerize -wait http://localhost:8000/swagger/ -timeout 20m
   build:
     working_directory: ~/CouncilTag-Django
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,18 @@
 version: 2
 jobs:
+  test:
+    working_directory: ~/CouncilTag-Django
+    machine: true
+    steps:
+      - checkout
+      - run: docker-compose build
+      - run: docker-compse up
+      - run:
+          name: install dockerize
+          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+          environment:
+            DOCKERIZE_VERSION: v0.3.0
+      - run: dockerize -wait http://0.0.0.0:8000/ -timeout 8m
   build:
     working_directory: ~/CouncilTag-Django
     docker:
@@ -55,6 +68,9 @@ jobs:
                 ssh -f $SSH_USER@$SSH_HOST "./deploy.sh"
 workflows:
  version: 2
+ check-compose:
+   jobs:
+     - test:
  build-and-deploy:
    jobs:
      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - checkout
       - run: docker-compose build
-      - run: docker-compose up
+      - run: docker-compose up -d
       - run:
           name: install dockerize
           command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
           environment:
             DOCKERIZE_VERSION: v0.3.0
-      - run: dockerize -wait http://0.0.0.0:8000/ -timeout 8m
+      - run: dockerize -wait http://0.0.0.0:8000/ -timeout 20m
   build:
     working_directory: ~/CouncilTag-Django
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ workflows:
  version: 2
  check-compose:
    jobs:
-     - test:
+     - test
  build-and-deploy:
    jobs:
      - build

--- a/CouncilTag/api/tests.py
+++ b/CouncilTag/api/tests.py
@@ -38,18 +38,18 @@ class TestTagsEndpoint(TestCase):
         self.assertGreaterEqual(len(seed_tags), len(response.json()))
 
 class TestLoginEndpoint(TestCase):
-    
-    
+
+
     def test_user_creation(self):
-        user_to_test_against = User.objects.create_user("test", email="test@test.com", password='test')       
+        user_to_test_against = User.objects.create_user("test", email="test@test.com", password='test')
         jwt_token = jwt.encode({'email':user_to_test_against.email}, settings.SECRET_KEY)
         response = self.client.post("/api/login.json", {'email':'test@test.com', 'password': 'test'})
         token = response.json()['token']
         #have to decode the jwt_token since it will be a byte-object and not string
         self.assertEqual(jwt_token.decode('utf-8'), token)
-    
+
     def test_user_wrong_info(self):
-        user_to_test_against = User.objects.create_user("test", email="test@test.com", password='test')       
+        user_to_test_against = User.objects.create_user("test", email="test@test.com", password='test')
         response = self.client.post("/api/login.json", {'email':'test@test.com', 'password': 'testing'})
         self.assertEqual(404, response.status_code)
 
@@ -115,12 +115,13 @@ class TestSendMessageEndpoint(TestCase):
     Add SES test
     '''
     def test_mail_util_func(self):
+        if os.environ.get("ENGAGE_BACKEND_NO_MAIL") == 'TRUE':
+            # Early Exit for CI runners without valid MAIL API KEY
+            return
         root_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
         static = 'PDF_Reports'
         full_path = os.path.join(root_dir, static)
-        attachment_file_path = str(full_path) + "/test_pdf_report.pdf" 
+        attachment_file_path = str(full_path) + "/test_pdf_report.pdf"
         print(attachment_file_path)
         result = send_mail({'user': {'email': 'engage@engage.town'}, 'subject': 'test', 'content': '<html><body>Testing</body></html>', 'attachment_file_path': attachment_file_path, 'attachment_file_name': 'test_pdf_report.pdf'})
         self.assertTrue(result)
-
-    


### PR DESCRIPTION
This addresses #146  I also added an early exit to the AWS Email test.  I think its useful for runners without access to the SES API Key, but can remove it.